### PR TITLE
Reorganize stages in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         stage('Test') {
             steps {
                 dir("openpaas-james") {
-                    sh 'mvn -B test'
+                    sh 'mvn -B surefire:test'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,13 +5,15 @@ pipeline {
         stage('Git checkout') {
             steps {
                 git 'https://github.com/linagora/openpaas-james'
+                sh 'git submodule init'
+                sh 'git submodule update'
             }
+        }
+        stage('Compile') {
+            sh 'mvn install -Dmaven.javadoc.skip=true -DskipTests -T1C'
         }
         stage('Test') {
             steps {
-                sh 'git submodule init'
-                sh 'git submodule update'
-                sh 'mvn install -Dmaven.javadoc.skip=true -DskipTests -T1C'
                 dir("openpaas-james") {
                     sh 'mvn -B test'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
             }
         }
         stage('Compile') {
-            sh 'mvn install -Dmaven.javadoc.skip=true -DskipTests -T1C'
+            sh 'mvn clean install -Dmaven.javadoc.skip=true -DskipTests -T1C'
         }
         stage('Test') {
             steps {


### PR DESCRIPTION
It made no sense to have the submodule fetch and the compilation of the project in the test stage of the pipeline.

It will increase readability in our CI pipeline UI for the job.