### PR TITLE
Add missing steps section in Compile stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
             }
         }
         stage('Compile') {
-            sh 'mvn clean install -Dmaven.javadoc.skip=true -DskipTests -T1C'
+            steps {
+                sh 'mvn clean install -Dmaven.javadoc.skip=true -DskipTests -T1C'
+            }
         }
         stage('Test') {
             steps {


### PR DESCRIPTION
The problem of not having builds for PRs yet... (and the fact I didn't test my Jenkinsfile locally either... yes throw me stones)

Well without the steps section, the all pipeline is broken and the build does not start on the CI