### PR TITLE
Add missing logback json dependency in distributed version

### DIFF
--- a/openpaas-james/apps/distributed/pom.xml
+++ b/openpaas-james/apps/distributed/pom.xml
@@ -246,6 +246,10 @@
             <artifactId>logback-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/openpaas-james/apps/memory/pom.xml
+++ b/openpaas-james/apps/memory/pom.xml
@@ -64,6 +64,10 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openpaas-james/pom.xml
+++ b/openpaas-james/pom.xml
@@ -518,6 +518,11 @@
                 <version>0.1.5</version>
             </dependency>
             <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-json-classic</artifactId>
+                <version>0.1.5</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>


### PR DESCRIPTION
We need it to generate logs in json for fluentbit to be able to scrap them