### PR TITLE
Add missing logback json dependency in distributed-es6-backport version

### DIFF
--- a/openpaas-james/apps/distributed-es6-backport/pom.xml
+++ b/openpaas-james/apps/distributed-es6-backport/pom.xml
@@ -250,6 +250,10 @@
             <artifactId>logback-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Yeah well... Same issue as last time, which makes crash the new release on preprod, that got missed on es6-backport as the work was in the same time and not finalized yet. Please help review and merge ASAP thanks :)